### PR TITLE
Allow actions for bracket (and other) to leave children

### DIFF
--- a/Control/Concurrent/Longrun/Timer.hs
+++ b/Control/Concurrent/Longrun/Timer.hs
@@ -71,11 +71,10 @@ newTimer seconds action = do
         }
 
 _withSemaphore :: Timer -> Process a -> Process a
-_withSemaphore t action = do
-    _ <- liftIO $ takeMVar (tSema t)
-    rv <- action
-    liftIO $ putMVar (tSema t) ()
-    return rv
+_withSemaphore t action = bracket takeSema releaseSema action' where
+    takeSema = liftIO $ takeMVar (tSema t)
+    releaseSema _ = liftIO $ putMVar (tSema t) ()
+    action' _ = action
 
 -- | Stop timer.
 _stopTimer :: Timer -> Process Bool

--- a/test/TestTimer.hs
+++ b/test/TestTimer.hs
@@ -80,13 +80,14 @@ timExpire = do
     _ <- restartTimer t
     sleep 0.01
     _ <- expireTimer t
+    sleep 0.01
     logM INFO "stop"
 
 testTimExpire :: Test
 testTimExpire = testLogsOfMatch "test timExpire" INFO timExpire
     [ (INFO,  "start")
-    , (INFO,  "stop")
     , (INFO,  "tick")
+    , (INFO,  "stop")
     ]
 
 


### PR DESCRIPTION
I figured out that `bracket` could not be used for e.g. `_withSemaphore` because it runs all three actions with `runProcess` which in turns terminates all children after each action completes. 

This means it's not possible to spawn tasks from inside the action as the killing will happen and the task (or timer etc) will not have a chance to complete. 

My hypothesis is that the control flow functions *should not* call `runProcess` and instead just "run inside current process". I implemented this by deconstructing `Process`, manually threading the config and binding over `IO` (same pattern as for implementing `ContT` instances). This gives access to the actions on the level of `IO` and allows us to use `IO` combinators directly.

I had the tests pass with this change but I'm still looking for some feedback whether this change is a step in the right direction or not.