### PR TITLE
Support GHC 8.4

### DIFF
--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -39,7 +39,7 @@ testLogsOfMatch name priority proc expected = buildTest $ do
 
 getUsedMemory :: IO Int64
 getUsedMemory = do
-    Mem.performGC  -- stats are only refresed after a GC cycle
+    Mem.performGC  -- stats are only refreshed after a GC cycle
 #if __GLASGOW_HASKELL__ < 802
     Stats.currentBytesUsed <$> Stats.getGCStats
 #else

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Utils where
 
 import Control.Exception (SomeException, catch)
@@ -37,8 +39,12 @@ testLogsOfMatch name priority proc expected = buildTest $ do
 
 getUsedMemory :: IO Int64
 getUsedMemory = do
-  Mem.performGC  -- stats are only refresed after a GC cycle
-  Stats.currentBytesUsed <$> Stats.getGCStats
+    Mem.performGC  -- stats are only refresed after a GC cycle
+#if __GLASGOW_HASKELL__ < 802
+    Stats.currentBytesUsed <$> Stats.getGCStats
+#else
+    fromIntegral . Stats.gcdetails_live_bytes . Stats.gc <$> Stats.getRTSStats
+#endif
 
 assertConstantMemory :: MonadIO m => Int64 -> Double -> m a -> m Assertion
 assertConstantMemory baseIterations maxRatio block = do


### PR DESCRIPTION
`getGCStats` was deprecated in GHC 8.2 and will be removed in 8.4.

I used the new API to implement the same functionality. Since it's only available since 8.2 I needed to use CPP extension to switch between implementation depending on the compiler version in order to remain compatible with older GHC versions.